### PR TITLE
Changes made in parse method to release the lock on file.

### DIFF
--- a/src/com/gizbel/excel/factory/Parser.java
+++ b/src/com/gizbel/excel/factory/Parser.java
@@ -1,7 +1,9 @@
 package com.gizbel.excel.factory;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.sql.Date;
 import java.text.ParseException;
@@ -196,7 +198,8 @@ public class Parser {
     public List<Object> parse(File file) throws InvalidFormatException, IOException, InstantiationException,
             IllegalAccessException, IllegalArgumentException, ParseException {
         List<Object> result = new ArrayList<>();
-        Workbook invoiceWorkbook = WorkbookFactory.create(file);
+        InputStream istrm = new FileInputStream(file);
+        Workbook invoiceWorkbook = WorkbookFactory.create(istrm);
 
         // Currently processing for one sheet, we can loop here for multiple
         // sheets
@@ -237,6 +240,7 @@ public class Parser {
                     break;
             }
         }
+        istrm.close();
         return result;
     }
 

--- a/src/com/gizbel/excel/test/Main.java
+++ b/src/com/gizbel/excel/test/Main.java
@@ -1,22 +1,29 @@
 package com.gizbel.excel.test;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import java.util.List;
 
 import com.gizbel.excel.enums.ExcelFactoryType;
 import com.gizbel.excel.factory.Parser;
+
 
 public class Main {
 
     public static void main(String[] args) throws Exception {
         Parser parser = new Parser(Bean.class, ExcelFactoryType.COLUMN_INDEX_BASED_EXTRACTION);
         parser.setSkipHeader(true);
-        List<Object> result = parser.parse(new File("test/inv.xlsx"));
+        File xlsFile = new File("test/inv.xlsx");
+        String newFilePath = "target/inv.xlsx";
+        List<Object> result = parser.parse(xlsFile);
         for (Object obj : result) {
             Bean bean = (Bean) obj;
             System.out.println(bean.toString());
             System.out.println();
         }
+        //Files.move(Paths.get(xlsFile.toPath().toString()), Paths.get(newFilePath), REPLACE_EXISTING);
     }
 
 }


### PR DESCRIPTION
If one tries to move the XLS file to some other location after reading it then it would throw following exception : 
Exception in thread "main" java.nio.file.FileSystemException: test\inv.xlsx -> target\inv.xlsx: The process cannot access the file because it is being used by another process.

	at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:86)
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
	at sun.nio.fs.WindowsFileCopy.move(WindowsFileCopy.java:387)
	at sun.nio.fs.WindowsFileSystemProvider.move(WindowsFileSystemProvider.java:287)
	at java.nio.file.Files.move(Files.java:1395)
	at com.gizbel.excel.test.Main.main(Main.java:26)

Fixed this issue, by using an inputStream to create a Workbook and then closed the stream in order to release the lock on file. 